### PR TITLE
Add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ protoc/*
 *.zip.*
 *.zip
 /monitoring/grafana/data
+checksums.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +900,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +954,31 @@ checksum = "1d34327ead1c743a10db339de35fb58957564b99d248a67985c55638b22c59b5"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clru"
@@ -1096,6 +1166,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -2429,6 +2537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,6 +3654,7 @@ dependencies = [
  "borsh 0.9.4",
  "bytes",
  "config",
+ "criterion",
  "futures",
  "futures-util",
  "getrandom 0.2.10",
@@ -3909,6 +4024,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -4438,6 +4559,34 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"
@@ -6177,6 +6326,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ metrics-exporter-prometheus = {version = "0.12.1", optional = true}
 tendermint = "0.33.0"
 tendermint-rpc = { version = "0.33.0", features = ["http-client"], default-features = false}
 tendermint-proto = "0.33.0"
-criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [patch.crates-io]
 borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ prometheus = ["metrics-exporter-prometheus", "axum-prometheus"]
 [[bench]]
 name = "save_blocks_bench"
 harness = false
+
+[[bench]]
+name = "get_block_bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ metrics-exporter-prometheus = {version = "0.12.1", optional = true}
 tendermint = "0.33.0"
 tendermint-rpc = { version = "0.33.0", features = ["http-client"], default-features = false}
 tendermint-proto = "0.33.0"
+criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [patch.crates-io]
 borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
@@ -55,8 +56,14 @@ borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev 
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports", "tokio", "async_futures"] }
 httpc-test = "0.1.4"
+
 
 [features]
 default = []
 prometheus = ["metrics-exporter-prometheus", "axum-prometheus"]
+
+[[bench]]
+name = "save_blocks_bench"
+harness = false

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ run_indexer: download-checksum
 run_server: download-checksum
 	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" RUST_LOG="namada_prototype=info" cargo r --release  --bin server --features prometheus
 
+benchmarks: download-checksum 
+	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" cargo bench 
+
 compose:
 	docker compose -f contrib/docker-compose.yaml up
 

--- a/benches/get_block_bench.rs
+++ b/benches/get_block_bench.rs
@@ -1,0 +1,86 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use namada_prototype::BlockInfo;
+use namada_prototype::{utils::load_checksums, Database};
+use sqlx::Row;
+use std::convert::TryFrom;
+
+use std::ops::Range;
+
+mod utils;
+
+const DATABASE_NAME: &str = "get_block_db";
+
+async fn tx_ids(db: &Database, block_id: &[u8]) -> Vec<Vec<u8>> {
+    let rows = db.get_tx_hashes_block(block_id).await.unwrap();
+
+    rows.iter()
+        .map(|row| {
+            let tx: Vec<u8> = row.try_get("hash").unwrap();
+            tx
+        })
+        .collect()
+}
+
+async fn get_blocks(db: &Database, blocks: Range<u32>) {
+    for idx in blocks {
+        let row = db
+            .block_by_height(idx)
+            .await
+            .unwrap()
+            .expect("block does not exist!!");
+
+        let block_id = BlockInfo::try_from(&row)
+            .expect("Failed parsing row -> BlockInfo")
+            .block_id;
+
+        _ = tx_ids(db, &block_id).await;
+    }
+}
+
+async fn prepare_database() -> Database {
+    // get helper database to create/destroy a new db used for this specific benchmark
+    let helper_db = utils::helper_db().await;
+
+    // destroy bench database if it exists
+    utils::destroy_bench_database(helper_db.pool(), DATABASE_NAME).await;
+
+    // a fresh state to ensure best benchmarking results
+    let db = utils::create_bench_database(helper_db.pool(), DATABASE_NAME).await;
+
+    db.create_tables().await.unwrap();
+
+    // populate bench database with blocks
+    let mut blocks = utils::load_blocks();
+    let checksums = load_checksums().unwrap();
+
+    utils::save_blocks(&db, blocks.iter_mut(), &checksums).await;
+
+    db
+}
+
+fn configure_criterion() -> Criterion {
+    Criterion::default().sample_size(10).noise_threshold(0.05) // 5% noise threshold
+}
+
+fn get_blocks_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let bench_db = rt.block_on(async { prepare_database().await });
+
+    // start benchmarking here
+    c.bench_function("get_block", |b| {
+        b.iter(|| {
+            // get all blocks per iteration
+            rt.block_on(async { get_blocks(&bench_db, 1..301).await });
+        });
+    });
+}
+
+criterion_group! {
+    name = get_block_bench;
+    config = configure_criterion();
+    targets = get_blocks_benchmark
+}
+
+criterion_main!(get_block_bench);

--- a/benches/save_blocks_bench.rs
+++ b/benches/save_blocks_bench.rs
@@ -1,110 +1,41 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use namada_prototype::{utils::load_checksums, Database, Settings};
-use sqlx::postgres::PgPoolOptions;
-use sqlx::query;
-use sqlx::PgPool;
-use std::collections::HashMap;
-use std::fs;
-use std::time::Duration;
-use tendermint::block::Block;
+use namada_prototype::utils::load_checksums;
 use tendermint::block::Height;
+
+mod utils;
 
 const DATABASE_NAME: &str = "bench_db";
 
-async fn create_db(pool: &PgPool, name: &str) {
-    // now create bench database
-    let db_query = format!("CREATE DATABASE {}", name);
-
-    query(&db_query)
-        .execute(pool)
-        .await
-        .expect("Could not create database for benchmarks");
-}
-
-async fn destroy_db(pool: &PgPool, name: &str) {
-    let db_query = format!("DROP DATABASE {}", name);
-
-    query(&db_query)
-        .execute(pool)
-        .await
-        .expect("Could not create database for benchmarks");
-}
-
-async fn create_bench_database(pg_pool: &PgPool) -> Database {
-    let config = Settings::new().unwrap();
-    let config = config.database_config();
-
-    // lets connect to our default database, so from there
-    // we create another database that is going to be used for
-    // benches.
-    create_db(pg_pool, DATABASE_NAME).await;
-
-    // Now connect to the just created db
-    let config = format!(
-        "postgres://{}:{}@{}/{}",
-        config.user, config.password, config.host, DATABASE_NAME,
-    );
-
-    let pool = PgPoolOptions::new()
-        .max_connections(10)
-        .acquire_timeout(Duration::from_secs(30))
-        .connect(&config)
-        .await
-        .expect("Could not connect to bench database");
-
-    Database::with_pool(pool)
-}
-
-async fn save_blocks_bench(
-    db: &Database,
-    blocks: impl Iterator<Item = &mut Block>,
-    checksums: &HashMap<String, String>,
-) {
-    for block in blocks {
-        // we need to update the block height
-        // to avoid collisions between bench runs
-        db.save_block(&block, &checksums).await.unwrap();
-    }
-}
-
 fn configure_criterion() -> Criterion {
-    Criterion::default()
-        .sample_size(100) // For example, set sample size
-        .noise_threshold(0.05) // 5% noise threshold
+    Criterion::default().sample_size(10).noise_threshold(0.05) // 5% noise threshold
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    let config = Settings::new().unwrap();
-    let config = config.database_config();
-
-    let checksums_map = load_checksums().unwrap();
-
-    let data = fs::read_to_string("./tests/blocks_vector.json").unwrap();
-    let mut blocks: Vec<Block> = serde_json::from_str(&data).unwrap();
-
-    let rt = tokio::runtime::Runtime::new().expect("could not create runtime");
-
-    // this database is used to connect to our default database which is used by tests.
-    // but we use it here to create an alternative database to use for benches
-    let db = rt.block_on(async { Database::new(config).await.unwrap() });
-
-    // destroy bench database if it exists
-    rt.block_on(async {
-        destroy_db(db.pool(), DATABASE_NAME).await;
-    });
+fn save_blocks_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
 
     let bench_db = rt.block_on(async {
-        let db = create_bench_database(db.pool()).await;
+        // get helper database to create/destroy a new db used for this specific benchmark
+        let helper_db = utils::helper_db().await;
+
+        // destroy bench database if it exists
+        utils::destroy_bench_database(helper_db.pool(), DATABASE_NAME).await;
+
+        // a fresh state to ensure best benchmarking results
+        let db = utils::create_bench_database(helper_db.pool(), DATABASE_NAME).await;
 
         db.create_tables().await.unwrap();
         db
     });
 
-    let mut block_idx: u32 = 0;
+    let mut block_idx: u32 = 1;
+
+    // load testing data
+    let mut blocks = utils::load_blocks();
+    let checksums_map = load_checksums().unwrap();
 
     // start benchmarking here
-    c.bench_function("function_name", |b| {
+    c.bench_function("save_block", |b| {
         b.iter(|| {
             rt.block_on(async {
                 // this allows us to avoid collisions
@@ -115,16 +46,15 @@ fn criterion_benchmark(c: &mut Criterion) {
                     b
                 });
 
-                save_blocks_bench(&bench_db, iter, &checksums_map).await
+                utils::save_blocks(&bench_db, iter, &checksums_map).await
             });
         });
     });
 }
 
-// criterion_group!(benches, criterion_benchmark);
 criterion_group! {
-    name = benches;
+    name = save_blocks_benches;
     config = configure_criterion();
-    targets = criterion_benchmark
+    targets = save_blocks_benchmark
 }
-criterion_main!(benches);
+criterion_main!(save_blocks_benches);

--- a/benches/save_blocks_bench.rs
+++ b/benches/save_blocks_bench.rs
@@ -1,0 +1,130 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use namada_prototype::{utils::load_checksums, Database, Settings};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::query;
+use sqlx::PgPool;
+use std::collections::HashMap;
+use std::fs;
+use std::time::Duration;
+use tendermint::block::Block;
+use tendermint::block::Height;
+
+const DATABASE_NAME: &str = "bench_db";
+
+async fn create_db(pool: &PgPool, name: &str) {
+    // now create bench database
+    let db_query = format!("CREATE DATABASE {}", name);
+
+    query(&db_query)
+        .execute(pool)
+        .await
+        .expect("Could not create database for benchmarks");
+}
+
+async fn destroy_db(pool: &PgPool, name: &str) {
+    let db_query = format!("DROP DATABASE {}", name);
+
+    query(&db_query)
+        .execute(pool)
+        .await
+        .expect("Could not create database for benchmarks");
+}
+
+async fn create_bench_database(pg_pool: &PgPool) -> Database {
+    let config = Settings::new().unwrap();
+    let config = config.database_config();
+
+    // lets connect to our default database, so from there
+    // we create another database that is going to be used for
+    // benches.
+    create_db(pg_pool, DATABASE_NAME).await;
+
+    // Now connect to the just created db
+    let config = format!(
+        "postgres://{}:{}@{}/{}",
+        config.user, config.password, config.host, DATABASE_NAME,
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .acquire_timeout(Duration::from_secs(30))
+        .connect(&config)
+        .await
+        .expect("Could not connect to bench database");
+
+    Database::with_pool(pool)
+}
+
+async fn save_blocks_bench(
+    db: &Database,
+    blocks: impl Iterator<Item = &mut Block>,
+    checksums: &HashMap<String, String>,
+) {
+    for block in blocks {
+        // we need to update the block height
+        // to avoid collisions between bench runs
+        db.save_block(&block, &checksums).await.unwrap();
+    }
+}
+
+fn configure_criterion() -> Criterion {
+    Criterion::default()
+        .sample_size(100) // For example, set sample size
+        .noise_threshold(0.05) // 5% noise threshold
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let config = Settings::new().unwrap();
+    let config = config.database_config();
+
+    let checksums_map = load_checksums().unwrap();
+
+    let data = fs::read_to_string("./tests/blocks_vector.json").unwrap();
+    let mut blocks: Vec<Block> = serde_json::from_str(&data).unwrap();
+
+    let rt = tokio::runtime::Runtime::new().expect("could not create runtime");
+
+    // this database is used to connect to our default database which is used by tests.
+    // but we use it here to create an alternative database to use for benches
+    let db = rt.block_on(async { Database::new(config).await.unwrap() });
+
+    // destroy bench database if it exists
+    rt.block_on(async {
+        destroy_db(db.pool(), DATABASE_NAME).await;
+    });
+
+    let bench_db = rt.block_on(async {
+        let db = create_bench_database(db.pool()).await;
+
+        db.create_tables().await.unwrap();
+        db
+    });
+
+    let mut block_idx: u32 = 0;
+
+    // start benchmarking here
+    c.bench_function("function_name", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                // this allows us to avoid collisions
+                // in the database, due to repeated blocks.
+                let iter = blocks.iter_mut().map(|b| {
+                    b.header.height = Height::from(block_idx);
+                    block_idx += 1;
+                    b
+                });
+
+                save_blocks_bench(&bench_db, iter, &checksums_map).await
+            });
+        });
+    });
+}
+
+// criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = configure_criterion();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/benches/save_blocks_bench.rs
+++ b/benches/save_blocks_bench.rs
@@ -5,7 +5,7 @@ use tendermint::block::Height;
 
 mod utils;
 
-const DATABASE_NAME: &str = "bench_db";
+const DATABASE_NAME: &str = "save_blocks_db";
 
 fn configure_criterion() -> Criterion {
     Criterion::default().sample_size(10).noise_threshold(0.05) // 5% noise threshold
@@ -14,7 +14,7 @@ fn configure_criterion() -> Criterion {
 fn save_blocks_benchmark(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let bench_db = rt.block_on(async {
+    let save_blocks_db = rt.block_on(async {
         // get helper database to create/destroy a new db used for this specific benchmark
         let helper_db = utils::helper_db().await;
 
@@ -46,7 +46,7 @@ fn save_blocks_benchmark(c: &mut Criterion) {
                     b
                 });
 
-                utils::save_blocks(&bench_db, iter, &checksums_map).await
+                utils::save_blocks(&save_blocks_db, iter, &checksums_map).await
             });
         });
     });

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -1,0 +1,74 @@
+use namada_prototype::{Database, Settings};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::query;
+use sqlx::PgPool;
+use std::collections::HashMap;
+use std::fs;
+use std::time::Duration;
+use tendermint::block::Block;
+
+async fn create_db(pool: &PgPool, name: &str) {
+    // now create bench database
+    let db_query = format!("CREATE DATABASE {}", name);
+
+    query(&db_query)
+        .execute(pool)
+        .await
+        .expect("Could not create database for benchmarks");
+}
+
+async fn destroy_db(pool: &PgPool, name: &str) {
+    let db_query = format!("DROP DATABASE {}", name);
+
+    _ = query(&db_query).execute(pool).await
+}
+
+pub async fn create_bench_database(pg_pool: &PgPool, name: &str) -> Database {
+    let config = Settings::new().unwrap();
+    let config = config.database_config();
+
+    // lets connect to our default database, so from there
+    // we create another database that is going to be used for
+    // benches.
+    create_db(pg_pool, name).await;
+
+    // Now connect to the just created db
+    let config = format!(
+        "postgres://{}:{}@{}/{}",
+        config.user, config.password, config.host, name,
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .acquire_timeout(Duration::from_secs(30))
+        .connect(&config)
+        .await
+        .expect("Could not connect to bench database");
+
+    Database::with_pool(pool)
+}
+
+pub async fn destroy_bench_database(pg_pool: &PgPool, name: &str) {
+    destroy_db(pg_pool, name).await
+}
+
+pub fn load_blocks() -> Vec<Block> {
+    let data = fs::read_to_string("./tests/blocks_vector.json").unwrap();
+    serde_json::from_str(&data).unwrap()
+}
+
+pub async fn helper_db() -> Database {
+    let config = Settings::new().unwrap();
+    let config = config.database_config();
+    Database::new(config).await.unwrap()
+}
+
+pub async fn save_blocks(
+    db: &Database,
+    blocks: impl Iterator<Item = &mut Block>,
+    checksums: &HashMap<String, String>,
+) {
+    for block in blocks {
+        db.save_block(&block, &checksums).await.unwrap();
+    }
+}


### PR DESCRIPTION
This includes:
- benchmark for saving blocks into database.
- benchmark for getting blocks from the database and their txs.

We are using criterion andthe provided test vectors which are also used for testing.
Criterion performs many iterations(configured here for 10 iterations) and on each iteration, we save/query all the blocks from the test vectors into/from the database.

There could be false positives, it would depend on the system loads at the moment benchmarks are executed and either the database is local or remote. but in general, It is an excellent way to measure changes that might come with regressions/improvements in performance.

It is possible to see a report via HTML, this report is located in `target/criterion/report/index.html`
if present, criterion will try to use gnuplot for the graphics.

this is an example:

![image](https://github.com/Zondax/namadexer/assets/7524579/9f82c1c4-4712-44ee-9a9c-d08d01cd2f24)
