### PR TITLE
Feat/eth txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,47 +3645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "namada-prototype"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "axum",
- "axum-prometheus",
- "borsh 0.9.4",
- "bytes",
- "config",
- "criterion",
- "futures",
- "futures-util",
- "getrandom 0.2.10",
- "hex",
- "httpc-test",
- "metrics",
- "metrics-exporter-prometheus",
- "namada",
- "opentelemetry",
- "opentelemetry-jaeger",
- "opentelemetry_api",
- "prost",
- "prost-types",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "serde_derive",
- "serde_json",
- "sqlx",
- "tendermint 0.33.0",
- "tendermint-proto 0.33.0",
- "tendermint-rpc 0.33.0",
- "thiserror",
- "time",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "namada_core"
 version = "0.21.1"
 source = "git+https://github.com/anoma/namada?tag=v0.21.1#1612bf1b637a02b0a87ff5f5995eb3bb87cd8715"
@@ -3779,6 +3738,47 @@ dependencies = [
  "once_cell",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "namadexer"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-prometheus",
+ "borsh 0.9.4",
+ "bytes",
+ "config",
+ "criterion",
+ "futures",
+ "futures-util",
+ "getrandom 0.2.10",
+ "hex",
+ "httpc-test",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "namada",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "opentelemetry_api",
+ "prost",
+ "prost-types",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sqlx",
+ "tendermint 0.33.0",
+ "tendermint-proto 0.33.0",
+ "tendermint-rpc 0.33.0",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "namada-prototype"
+name = "namadexer"
 version = "0.1.0"
 edition = "2021"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN apt-get update && rm -rf /var/lib/apt/lists/*
 
 # default env
 ENV INDEXER_CONFIG_PATH "/app/config/Settings.toml"
-ENV RUST_LOG "namada_prototype=debug"
+ENV RUST_LOG "namadexer=debug"
 
 CMD indexer

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ build: download-checksum
 	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" cargo build --features prometheus
 
 run_indexer: download-checksum
-	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" RUST_LOG="namada_prototype=info" cargo r --release --bin indexer --features prometheus
+	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" RUST_LOG="namadexer=info" cargo r --release --bin indexer --features prometheus
 
 run_server: download-checksum
-	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" RUST_LOG="namada_prototype=info" cargo r --release  --bin server --features prometheus
+	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" RUST_LOG="namadexer=info" cargo r --release  --bin server --features prometheus
 
 benchmarks: download-checksum 
 	INDEXER_CONFIG_PATH="${PWD}/config/Settings.toml" PATH="${PWD}/protoc/bin:${PATH}" cargo bench 

--- a/benches/get_block_bench.rs
+++ b/benches/get_block_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use namada_prototype::BlockInfo;
-use namada_prototype::{utils::load_checksums, Database};
+use namadexer::BlockInfo;
+use namadexer::{utils::load_checksums, Database};
 use sqlx::Row;
 use std::convert::TryFrom;
 

--- a/benches/save_blocks_bench.rs
+++ b/benches/save_blocks_bench.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use namada_prototype::utils::load_checksums;
+use namadexer::utils::load_checksums;
 use tendermint::block::Height;
 
 mod utils;

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -1,4 +1,4 @@
-use namada_prototype::{Database, Settings};
+use namadexer::{Database, Settings};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::query;
 use sqlx::PgPool;

--- a/contrib/docker-compose.yaml
+++ b/contrib/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     build: ../.
     container_name: indexer
     environment:
-      - RUST_LOG="namada_prototype=debug"
+      - RUST_LOG="namadexer=debug"
       - INDEXER_CONFIG_PATH=/app/config/Settings.toml
     volumes:
       - ../config:/app/config
@@ -27,7 +27,7 @@ services:
     build: ../.
     container_name: server
     environment:
-      - RUST_LOG="namada_prototype=debug"
+      - RUST_LOG="namadexer=debug"
       - INDEXER_CONFIG_PATH=/app/config/Settings.toml
     volumes:
        - ../config:/app/config

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,7 +20,7 @@ services:
     build: ../.
     container_name: indexer
     environment:
-      - RUST_LOG="namada_prototype=debug"
+      - RUST_LOG="namadexer=debug"
       - INDEXER_CONFIG_PATH=/app/config/Settings.toml
     volumes:
       - ../config:/app/config
@@ -33,7 +33,7 @@ services:
     build: ../.
     container_name: server
     environment:
-      - RUST_LOG="namada_prototype=debug"
+      - RUST_LOG="namadexer=debug"
       - INDEXER_CONFIG_PATH=/app/config/Settings.toml
     volumes:
        - ../config:/app/config

--- a/src/bin/indexer.rs
+++ b/src/bin/indexer.rs
@@ -1,14 +1,14 @@
-use namada_prototype::setup_logging;
-use namada_prototype::start_indexing;
-use namada_prototype::Database;
-use namada_prototype::Error;
+use namadexer::setup_logging;
+use namadexer::start_indexing;
+use namadexer::Database;
+use namadexer::Error;
 
 use tracing::info;
 
 #[cfg(feature = "prometheus")]
-use namada_prototype::PrometheusConfig;
+use namadexer::PrometheusConfig;
 
-use namada_prototype::Settings;
+use namadexer::Settings;
 
 #[cfg(feature = "prometheus")]
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
@@ -36,7 +36,7 @@ async fn start_metrics_server(cfg: &PrometheusConfig) -> Result<(), Error> {
             DB_SAVE_DATA_DURATION_MS_BUCKETS,
         )?
         .set_buckets_for_metric(
-            Matcher::Prefix(namada_prototype::INDEXER_GET_BLOCK_DURATION.to_string()),
+            Matcher::Prefix(namadexer::INDEXER_GET_BLOCK_DURATION.to_string()),
             GET_BLOCK_DURATION_SECONDS_BUCKETS,
         )?
         .install()

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,8 +1,8 @@
-use namada_prototype::setup_logging;
-use namada_prototype::start_server;
-use namada_prototype::Database;
-use namada_prototype::Error;
-use namada_prototype::Settings;
+use namadexer::setup_logging;
+use namadexer::start_server;
+use namadexer::Database;
+use namadexer::Error;
+use namadexer::Settings;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> Result<(), Error> {

--- a/src/database.rs
+++ b/src/database.rs
@@ -645,6 +645,10 @@ impl Database {
             .execute(&*self.pool)
             .await?;
 
+        query("ALTER TABLE tx_bridge_pool ADD CONSTRAINT pk_tx_id_bridge PRIMARY KEY (tx_id);")
+            .execute(&*self.pool)
+            .await?;
+
         query("CREATE INDEX x_validator_bond ON tx_bond USING HASH (validator);")
             .execute(&*self.pool)
             .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod database;
 mod error;
 mod indexer;
 pub mod server;
+pub mod tables;
 mod telemetry;
 pub mod utils;
 
@@ -11,6 +12,10 @@ pub use database::Database;
 pub use error::Error;
 pub use indexer::start_indexing;
 pub use server::{create_server, start_server, BlockInfo};
+pub use tables::{
+    BLOCK_TABLE, EVIDENCES_TABLE, TRANSACTIONS_TABLE, TX_BOND_TABLE, TX_BRIDGE_POOL_TABLE,
+    TX_TRANSFER_TABLE,
+};
 pub use telemetry::{get_subscriber, init_subscriber, setup_logging};
 
 pub const INDEXER_GET_BLOCK_DURATION: &str = "indexer_get_block_duration";

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,0 +1,70 @@
+pub const BLOCK_TABLE: &str = "CREATE TABLE IF NOT EXISTS blocks (
+                block_id BYTEA NOT NULL,
+                header_version_app INTEGER NOT NULL,
+                header_version_block INTEGER NOT NULL,
+                header_chain_id TEXT NOT NULL,
+                header_height INTEGER NOT NULL,
+                header_time TEXT NOT NULL,
+                header_last_block_id_hash BYTEA,
+                header_last_block_id_parts_header_total INTEGER,
+                header_last_block_id_parts_header_hash BYTEA,
+                header_last_commit_hash BYTEA,
+                header_data_hash BYTEA,
+                header_validators_hash BYTEA NOT NULL,
+                header_next_validators_hash BYTEA NOT NULL,
+                header_consensus_hash BYTEA NOT NULL,
+                header_app_hash TEXT NOT NULL,
+                header_last_results_hash BYTEA,
+                header_evidence_hash BYTEA,
+                header_proposer_address TEXT NOT NULL,
+                commit_height INTEGER,
+                commit_round INTEGER,
+                commit_block_id_hash BYTEA,
+                commit_block_id_parts_header_total INTEGER,
+                commit_block_id_parts_header_hash BYTEA
+            );";
+
+pub const TRANSACTIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS transactions (
+                hash BYTEA NOT NULL,
+                block_id BYTEA NOT NULL,
+                tx_type TEXT NOT NULL,
+                code BYTEA,
+                data BYTEA
+            );";
+
+pub const EVIDENCES_TABLE: &str = "CREATE TABLE IF NOT EXISTS evidences (
+                block_id BYTEA NOT NULL,
+                height INTEGER,
+                time TEXT,
+                address BYTEA,
+                total_voting_power TEXT NOT NULL,
+                validator_power TEXT NOT NULL
+            );";
+
+pub const TX_TRANSFER_TABLE: &str = "CREATE TABLE IF NOT EXISTS tx_transfer (
+                tx_id BYTEA NOT NULL,
+                source TEXT NOT NULL,
+                target TEXT NOT NULL,
+                token TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                key TEXT,
+                shielded BYTEA
+            );";
+
+pub const TX_BOND_TABLE: &str = "CREATE TABLE IF NOT EXISTS tx_bond (
+                tx_id BYTEA NOT NULL,
+                validator TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                source TEXT,
+                bond BOOL NOT NULL
+            );";
+
+pub const TX_BRIDGE_POOL_TABLE: &str = "CREATE TABLE IF NOT EXISTS tx_bridge_pool (
+                tx_id BYTEA NOT NULL,
+                asset TEXT NOT NULL,
+                recipient TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                gas_amount TEXT NOT NULL,
+                payer TEXT NOT NULL
+            );";

--- a/tests/block_tests.rs
+++ b/tests/block_tests.rs
@@ -4,9 +4,9 @@ use utils::start_server;
 
 #[cfg(test)]
 mod block_tests {
-    use namada_prototype::BlockInfo;
-    use namada_prototype::Database;
-    use namada_prototype::Settings;
+    use namadexer::BlockInfo;
+    use namadexer::Database;
+    use namadexer::Settings;
 
     use super::*;
 

--- a/tests/save_block.rs
+++ b/tests/save_block.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod save_block {
-    use namada_prototype::utils::load_checksums;
-    use namada_prototype::Database;
-    use namada_prototype::Settings;
+    use namadexer::utils::load_checksums;
+    use namadexer::Database;
+    use namadexer::Settings;
     use std::fs;
     use tendermint::block::Block;
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,9 +1,9 @@
 use std::net::SocketAddr;
 
-use namada_prototype::create_server;
-use namada_prototype::Database;
-use namada_prototype::Error as NError;
-use namada_prototype::ServerConfig;
+use namadexer::create_server;
+use namadexer::Database;
+use namadexer::Error as NError;
+use namadexer::ServerConfig;
 
 // start a server and return its address
 pub fn start_server(db: Database) -> Result<SocketAddr, NError> {


### PR DESCRIPTION
This adds support for tx_bridge_pool transactions. 
- At the moment only TransactionToEthereum is supported not only by the indexer but [Namada](https://github.com/anoma/namada/blob/main/wasm/wasm_source/src/tx_bridge_pool.rs#L11).
- As part of the changes a new table is created for this transaction.
The crate name was also updated to namadexer, removing the prototype suffix that was previously used.