### PR TITLE
misc: specify in Settings.toml if http or https url for tendermint

### DIFF
--- a/config/Settings.example.toml
+++ b/config/Settings.example.toml
@@ -16,7 +16,7 @@ serve_at = "0.0.0.0"
 port = 30303
 
 [indexer]
-tendermint_addr = "127.0.0.1"
+tendermint_addr = "http://127.0.0.1"
 port = 26657
 
 [jaeger]

--- a/docs/03-indexer.md
+++ b/docs/03-indexer.md
@@ -20,7 +20,7 @@ dbname = "blockchain"
 
 # The tendermint RPC address and port to access the Namada node
 [indexer]
-tendermint_addr = "127.0.0.1"
+tendermint_addr = "http://127.0.0.1"
 port = 26657
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ const ENV_VAR_NAME: &str = "INDEXER_CONFIG_PATH";
 pub const SERVER_ADDR: &str = "127.0.0.1";
 pub const SERVER_PORT: u16 = 30303;
 
-pub const TENDERMINT_ADDR: &str = "127.0.0.1";
+pub const TENDERMINT_ADDR: &str = "http://127.0.0.1";
 pub const INDEXER_PORT: u16 = 27657;
 
 pub const JAEGER_HOST: &str = "localhost";

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -140,7 +140,7 @@ pub async fn start_indexing(db: Database, config: &IndexerConfig) -> Result<(), 
      ********************/
 
     // Connect to a RPC
-    let fmt_addr = format!("http://{}:{}", config.tendermint_addr, config.port);
+    let fmt_addr = format!("{}:{}", config.tendermint_addr, config.port);
     info!("Connecting to {}", fmt_addr);
     let client = HttpClient::new(fmt_addr.as_str())?;
 


### PR DESCRIPTION
closes #21 

We can now specify in the `Setting.toml` file if the tendermint url is http or https.