### PR TITLE
feat: gas information for wrapped tx

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -638,7 +638,6 @@ impl Database {
             let mut fee_token = String::new();
             let mut gas_limit_multiplier = 0;
             if let TxType::Wrapper(txw) = tx.header().tx_type {
-                dbg!(&txw);
                 fee_amount_per_gas_unit = txw.fee.amount_per_gas_unit.raw_amount().to_string();
                 fee_token = txw.fee.token.to_string();
                 // WARNING! converting into i64 might ended up changing the value but there is little

--- a/src/database.rs
+++ b/src/database.rs
@@ -465,7 +465,6 @@ impl Database {
             let tx = proto::Tx::try_from(t.as_slice()).map_err(|_| Error::InvalidTxData)?;
             let mut code = Default::default();
 
-
             // Decrypted transaction give access to the raw data
             if let TxType::Decrypted(..) = tx.header().tx_type {
                 code = tx
@@ -666,7 +665,17 @@ impl Database {
         let res = query_builder
             .push_values(
                 tx_values.into_iter(),
-                |mut b, (hash, block_id, tx_type, fee_amount_per_gas_unit, fee_token, fee_gas_limit_multiplier, code, data)| {
+                |mut b,
+                 (
+                    hash,
+                    block_id,
+                    tx_type,
+                    fee_amount_per_gas_unit,
+                    fee_token,
+                    fee_gas_limit_multiplier,
+                    code,
+                    data,
+                )| {
                     b.push_bind(hash)
                         .push_bind(block_id)
                         .push_bind(tx_type)

--- a/src/server/tx.rs
+++ b/src/server/tx.rs
@@ -80,7 +80,7 @@ pub struct TxInfo {
     fee_token: String,
     /// Gas limit (only for Wrapper tx)
     gas_limit_multiplier: i64,
-    /// The transaction code. Match what is in the checksum.js 
+    /// The transaction code. Match what is in the checksum.js
     #[serde(serialize_with = "serialize_optional_hex")]
     code: Option<Vec<u8>>,
     #[serde(serialize_with = "serialize_optional_hex")]

--- a/src/server/tx.rs
+++ b/src/server/tx.rs
@@ -28,7 +28,7 @@ use sqlx::Row as TRow;
 // represents the number of columns
 // that db must contains in order to deserialized
 // transactions
-const NUM_TX_COLUMNS: usize = 5;
+const NUM_TX_COLUMNS: usize = 8;
 
 // namada::ibc::applications::transfer::msgs::transfer::TYPE_URL has been made private and can't be access anymore
 const MSG_TRANSFER_TYPE_URL: &str = "/ibc.applications.transfer.v1.MsgTransfer";
@@ -75,6 +75,12 @@ pub struct TxInfo {
     block_id: Vec<u8>,
     /// The transaction type encoded as a string
     tx_type: String,
+    /// The transaction fee only for tx_type Wrapper (otherwise empty)
+    fee_amount_per_gas_unit: String,
+    fee_token: String,
+    /// Gas limit (only for Wrapper tx)
+    gas_limit_multiplier: i64,
+    /// The transaction code. Match what is in the checksum.js 
     #[serde(serialize_with = "serialize_optional_hex")]
     code: Option<Vec<u8>>,
     #[serde(serialize_with = "serialize_optional_hex")]
@@ -181,6 +187,9 @@ impl TryFrom<Row> for TxInfo {
         let hash: Vec<u8> = row.try_get("hash")?;
         let block_id: Vec<u8> = row.try_get("block_id")?;
         let tx_type: String = row.try_get("tx_type")?;
+        let fee_amount_per_gas_unit = row.try_get("fee_amount_per_gas_unit")?;
+        let fee_token = row.try_get("fee_token")?;
+        let gas_limit_multiplier = row.try_get("gas_limit_multiplier")?;
         let code: Option<Vec<u8>> = row.try_get("code")?;
         let data: Option<Vec<u8>> = row.try_get("data")?;
 
@@ -188,6 +197,9 @@ impl TryFrom<Row> for TxInfo {
             hash,
             block_id,
             tx_type,
+            fee_amount_per_gas_unit,
+            fee_token,
+            gas_limit_multiplier,
             code,
             data,
             tx: None,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -35,6 +35,9 @@ pub fn get_create_transactions_table_query(network: &str) -> String {
         hash BYTEA NOT NULL,
         block_id BYTEA NOT NULL,
         tx_type TEXT NOT NULL,
+        fee_amount_per_gas_unit TEXT,
+        fee_token TEXT,
+        gas_limit_multiplier BIGINT,
         code BYTEA,
         data BYTEA
     );",


### PR DESCRIPTION
closes #32 

This PR add the tx info on gas for wrapped transaction. It will give the amount per gas unit fee, the token it is in and the gas limit.

The server API also reflect those info.