### PR TITLE
Organize endpoint implementations

### DIFF
--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -1,0 +1,3 @@
+pub mod account;
+pub mod block;
+pub mod transaction;

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -1,3 +1,2 @@
-pub mod account;
 pub mod block;
 pub mod transaction;

--- a/src/server/endpoints/block.rs
+++ b/src/server/endpoints/block.rs
@@ -1,0 +1,79 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use sqlx::Row as TRow;
+use tracing::info;
+
+use crate::{
+    server::{blocks::HashID, ServerState},
+    BlockInfo, Error,
+};
+
+async fn get_tx_hashes(
+    state: &ServerState,
+    block: &mut BlockInfo,
+    hash: &[u8],
+) -> Result<(), Error> {
+    let rows = state.db.get_tx_hashes_block(hash).await?;
+
+    let mut tx_hashes: Vec<HashID> = vec![];
+    for row in rows.iter() {
+        let hash = HashID(row.try_get("hash")?);
+        tx_hashes.push(hash);
+    }
+
+    block.tx_hashes = tx_hashes;
+
+    Ok(())
+}
+
+pub async fn get_block_by_hash(
+    State(state): State<ServerState>,
+    Path(hash): Path<String>,
+) -> Result<Json<Option<BlockInfo>>, Error> {
+    info!("calling /block/hash/:block_hash");
+
+    let id = hex::decode(hash)?;
+
+    let row = state.db.block_by_id(&id).await?;
+    let Some(row) = row else {
+        return Ok(Json(None));
+    };
+    let mut block = BlockInfo::try_from(&row)?;
+
+    let block_id: Vec<u8> = row.try_get("block_id")?;
+    get_tx_hashes(&state, &mut block, &block_id).await?;
+
+    Ok(Json(Some(block)))
+}
+
+pub async fn get_block_by_height(
+    State(state): State<ServerState>,
+    Path(height): Path<u32>,
+) -> Result<Json<Option<BlockInfo>>, Error> {
+    info!("calling /block/height/:block_height");
+
+    let row = state.db.block_by_height(height).await?;
+    let Some(row) = row else {
+        return Ok(Json(None));
+    };
+
+    let mut block = BlockInfo::try_from(&row)?;
+
+    let block_id: Vec<u8> = row.try_get("block_id")?;
+    get_tx_hashes(&state, &mut block, &block_id).await?;
+
+    Ok(Json(Some(block)))
+}
+
+pub async fn get_last_block(State(state): State<ServerState>) -> Result<Json<BlockInfo>, Error> {
+    let row = state.db.get_last_block().await?;
+
+    let mut block = BlockInfo::try_from(&row)?;
+
+    let block_id: Vec<u8> = row.try_get("block_id")?;
+    get_tx_hashes(&state, &mut block, &block_id).await?;
+
+    Ok(Json(block))
+}

--- a/src/server/endpoints/transaction.rs
+++ b/src/server/endpoints/transaction.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use tracing::info;
+
+use crate::{
+    server::{shielded, ServerState, TxInfo},
+    Error,
+};
+
+pub async fn get_tx_by_hash(
+    State(state): State<ServerState>,
+    Path(hash): Path<String>,
+) -> Result<Json<Option<TxInfo>>, Error> {
+    info!("calling /tx/:tx_hash");
+
+    let hash = hex::decode(hash)?;
+
+    let row = state.db.get_tx(&hash).await?;
+    let Some(row) = row else {
+        return Ok(Json(None));
+    };
+    let mut tx = TxInfo::try_from(row)?;
+
+    // ignore the error for now
+    _ = tx.decode_tx(&state.checksums_map);
+
+    Ok(Json(Some(tx)))
+}
+
+// Return a list of the shielded assets and their total compiled using all the shielded transactions (in, internal and out)
+pub async fn get_shielded_tx(
+    State(state): State<ServerState>,
+) -> Result<Json<shielded::ShieldedAssetsResponse>, Error> {
+    let rows = state.db.get_shielded_tx().await?;
+
+    let shielded_assests_response = shielded::ShieldedAssetsResponse::try_from(&rows)?;
+
+    Ok(Json(shielded_assests_response))
+}


### PR DESCRIPTION
This re-organizes the endpoint implementation better, instead of being spread across the module file, separating concerns and functionality. This could come in handy when more endpoints would be added for example for dealing with accounts.