### PR TITLE
Feat/account tables

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -62,6 +62,7 @@ impl Database {
             "postgres://{}:{}@{}/{}",
             db_config.user, db_config.password, db_config.host, db_config.dbname
         );
+        println!("config: {}", config);
 
         // If timeout setting is not present in the provided configuration,
         // lets use our default timeout.
@@ -101,9 +102,9 @@ impl Database {
     /// - `evidences` Where block's evidence data is stored.
     #[instrument(skip(self))]
     pub async fn create_tables(&self) -> Result<(), Error> {
-        info!("Creating tables if doesn't exist");
+        info!("Creating tables if they don't exist");
 
-        query(format!("CREATE SCHEMA IF NOT EXISTS {}", self.network).as_str())
+        query(&format!("CREATE SCHEMA IF NOT EXISTS {}", self.network))
             .execute(&*self.pool)
             .await?;
 
@@ -134,9 +135,11 @@ impl Database {
         query(get_create_tx_bridge_pool_table_query(&self.network).as_str())
             .execute(&*self.pool)
             .await?;
+
         query(get_create_account_updates_table(&self.network).as_str())
             .execute(&*self.pool)
             .await?;
+
         query(get_create_account_public_keys_table(&self.network).as_str())
             .execute(&*self.pool)
             .await?;
@@ -999,16 +1002,6 @@ impl Database {
                 "CREATE INDEX x_source_bond ON {}.tx_bond (source);",
                 self.network
             )
-            .as_str(),
-        )
-        .execute(&*self.pool)
-        .await?;
-
-        query(
-            format!(
-            "ALTER TABLE {}.account_updates ADD CONSTRAINT pk_update_id PRIMARY KEY (update_id);",
-            self.network
-        )
             .as_str(),
         )
         .execute(&*self.pool)

--- a/src/database.rs
+++ b/src/database.rs
@@ -1160,17 +1160,17 @@ impl Database {
     /// Returns a list of vp_code_hashes sorted in ascending order using
     /// update_id which act as a kind of timestamp between updates.
     /// In case accound_id does not exists, this method returns Ok(None)
-    pub async fn account_vp_codes(&self, account_id: &str) -> Result<Vec<Row>, Error> {
+    pub async fn account_vp_codes(&self, account_id: &str) -> Result<Option<Row>, Error> {
         let to_query = r#"
-            SELECT vp_code_hash
+            SELECT ARRAY_AGG(vp_code_hash ORDER BY update_id ASC) AS code_hashes
             FROM account_updates
             WHERE account_id = $1
-            ORDER BY update_id ASC;
+            GROUP BY account_id;
         "#;
 
         query(to_query)
             .bind(account_id)
-            .fetch_all(&*self.pool)
+            .fetch_optional(&*self.pool)
             .await
             .map_err(Error::from)
     }

--- a/src/server/account.rs
+++ b/src/server/account.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+/// The relevant information regarding accounts.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct AccountUpdates {
+    /// Address that identifies this account
+    pub account_id: String,
+    // The list of vp_code_hashes that this account
+    // has been updated with, being the last element in
+    // the list the current code_hash this account uses.
+    pub code_hashes: Vec<String>,
+
+    /// The list of thresholds that have been configured to
+    /// this account. Similar to code hash, the last element
+    /// is the threshold being used by this account.
+    pub thresholds: Vec<u8>,
+
+    /// The list of public_keys sets that this accounts uses.
+    /// Similar to code hash, the last element
+    /// is contains the set of public keys this account is associated with.
+    pub public_keys: Vec<Vec<String>>,
+}

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -1,2 +1,3 @@
+pub mod account;
 pub mod block;
 pub mod transaction;

--- a/src/server/endpoints/account.rs
+++ b/src/server/endpoints/account.rs
@@ -45,12 +45,12 @@ pub async fn get_account_updates(
     let thresholds_result = state.db.account_thresholds(&account_id).await?;
 
     let Some(thresholds_row) = thresholds_result else {
-            return Ok(Json(None))
-        };
+        return Ok(Json(None));
+    };
 
-    let Some(code_row)  = state.db.account_vp_codes(&account_id).await? else {
-            return Ok(Json(None))
-        };
+    let Some(code_row) = state.db.account_vp_codes(&account_id).await? else {
+        return Ok(Json(None));
+    };
 
     let public_keys_result = state.db.account_public_keys(&account_id).await?;
 

--- a/src/server/endpoints/account.rs
+++ b/src/server/endpoints/account.rs
@@ -1,0 +1,78 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+
+use crate::{
+    server::{account::AccountUpdates, ServerState},
+    Error,
+};
+use sqlx::Row as TRow;
+
+/// Retrieves the update history for a specific account.
+///
+/// This function handles a web request that queries the update history of a specified account.
+/// It returns the updates in JSON format, with each field representing a different aspect
+/// of the account that has been updated. The updates are returned in an ordered manner for each field.
+///
+/// # Arguments
+///
+/// * `account_id`: - The identifier of the account. This is extracted from the URL path
+///   as a path parameter.
+///
+/// # Returns
+///
+/// On success, returns a JSON representation of the
+///   account's update history. If no updates are found for the given account, `None` is returned.
+///   On failure, returns an `Error`.
+///
+/// # Example
+///
+/// ```no_run
+/// // Assuming the function is part of a route handler in a web application:
+/// // GET /account/updates/{account_id}
+/// // Where {account_id} is a dynamic path parameter(Address formatted as an string) representing the account ID.
+/// ```
+///
+/// # Errors
+///
+/// This function may return errors related to database access, data serialization, or other
+/// issues encountered during the processing of the request.
+pub async fn get_account_updates(
+    State(state): State<ServerState>,
+    Path(account_id): Path<String>,
+) -> Result<Json<Option<AccountUpdates>>, Error> {
+    let thresholds_result = state.db.account_thresholds(&account_id).await?;
+
+    let Some(thresholds_row) = thresholds_result else {
+            return Ok(Json(None))
+        };
+
+    let Some(code_row)  = state.db.account_vp_codes(&account_id).await? else {
+            return Ok(Json(None))
+        };
+
+    let public_keys_result = state.db.account_public_keys(&account_id).await?;
+
+    let thresholds = thresholds_row
+        .try_get::<Vec<i32>, _>("thresholds")?
+        .into_iter()
+        .map(|v| v as u8)
+        .collect::<Vec<u8>>(); // Specify the type for collect
+
+    // Add vp_codes to the combined row
+    let code_hashes: Vec<String> = code_row.try_get("code_hashes")?;
+
+    // Add public_keys to the combined row
+    let public_keys = public_keys_result
+        .into_iter()
+        .filter_map(|r| r.try_get::<Vec<String>, _>("public_keys_batch").ok())
+        .collect();
+
+    Ok(Json(Some(AccountUpdates {
+        account_id,
+        thresholds,
+        code_hashes,
+        public_keys,
+    })))
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,12 +17,14 @@ pub mod blocks;
 pub mod tx;
 pub use blocks::BlockInfo;
 pub use tx::TxInfo;
+pub mod account;
 mod endpoints;
 pub mod shielded;
 mod utils;
 pub(crate) use utils::{from_hex, serialize_hex};
 
 use self::endpoints::{
+    account::get_account_updates,
     block::{get_block_by_hash, get_block_by_height, get_last_block},
     transaction::{get_shielded_tx, get_tx_by_hash},
 };
@@ -44,6 +46,7 @@ fn server_routes(state: ServerState) -> Router<()> {
         .route("/block/last", get(get_last_block))
         .route("/tx/:tx_hash", get(get_tx_by_hash))
         .route("/shielded", get(get_shielded_tx))
+        .route("/account/updates/:account_id", get(get_account_updates))
         .with_state(state)
 }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -119,6 +119,12 @@ pub fn get_create_commit_signatures_table_query(network: &str) -> String {
 // in a sort of batches, where each batch was a new set of pub_keys for which and account
 // was updated in a account_update transaction.
 pub fn get_create_account_updates_table(network: &str) -> String {
+    // NOTE: We are creating the index here as well so it
+    // is used as  reference by the account_public_keys table.
+    // Otherwise postgres complains when creating that table
+    // due to the missing primary index in account_updates.
+    // Importan to mention that update_id is use to link public keys
+    // to an update in time.
     format!(
         "CREATE TABLE IF NOT EXISTS {}.account_updates (
         update_id SERIAL PRIMARY KEY,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -114,3 +114,31 @@ pub fn get_create_commit_signatures_table_query(network: &str) -> String {
         network
     )
 }
+// To store account_updates transactions
+// the update_id is used primarly for getting all the public keys for account_id
+// in a sort of batches, where each batch was a new set of pub_keys for which and account
+// was updated in a account_update transaction.
+pub fn get_create_account_updates_table(network: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {}.account_updates (
+        update_id SERIAL,
+        account_id TEXT NOT NULL,
+        vp_code_hash BYTEA,
+        threshold INTEGER
+    );",
+        network,
+    )
+}
+
+// To be use by the account_init and account_update transactions
+// any account can have many pub_keys
+pub fn get_create_account_public_keys_table(network: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {}.account_public_keys (
+        id SERIAL,
+        update_id INTEGER REFERENCES {}.account_updates(update_id),
+        public_key TEXT NOT NULL
+    );",
+        network, network
+    )
+}

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -121,7 +121,7 @@ pub fn get_create_commit_signatures_table_query(network: &str) -> String {
 pub fn get_create_account_updates_table(network: &str) -> String {
     format!(
         "CREATE TABLE IF NOT EXISTS {}.account_updates (
-        update_id SERIAL,
+        update_id SERIAL PRIMARY KEY,
         account_id TEXT NOT NULL,
         vp_code_hash BYTEA,
         threshold INTEGER
@@ -136,7 +136,7 @@ pub fn get_create_account_public_keys_table(network: &str) -> String {
     format!(
         "CREATE TABLE IF NOT EXISTS {}.account_public_keys (
         id SERIAL,
-        update_id INTEGER REFERENCES {}.account_updates(update_id),
+        update_id INTEGER UNIQUE REFERENCES {}.account_updates(update_id),
         public_key TEXT NOT NULL
     );",
         network, network


### PR DESCRIPTION
This add:
- Tables to store account_updates transactions
- auxiliary public_keys table 
- method to retrieve historical updates for a specific account.
- endpoint to retrieve historical updates for accounts.

Even though we index data from **tx_inti_account**, which outlines the initial state of an account, it notably lacks an account_id. This omission is logical, considering the account is yet to be created. Consequently, we can't establish a connection between an update and an init_account transaction. For this reason, we've chosen to focus solely on tracking account updates. To accommodate this, we've created a specific endpoint that allows users to retrieve this information by submitting an account_id (Address).

@Fraccaman more insights on this would be helpful, how could we link a tx_init_account to a later tx_update_account?
