### PR TITLE
feat: add wrapper tx id for decrypted transaction

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -11,7 +11,7 @@ use namada::types::{
 };
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow as Row};
 use sqlx::Row as TRow;
-use sqlx::{query, Executor, QueryBuilder, Transaction};
+use sqlx::{query, QueryBuilder, Transaction};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/database.rs
+++ b/src/database.rs
@@ -10,7 +10,7 @@ use namada::types::{
     transaction::{self, account::UpdateAccount, pgf::UpdateStewardCommission, TxType},
 };
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow as Row};
-use sqlx::{query, QueryBuilder, Transaction};
+use sqlx::{query, QueryBuilder, Transaction, Executor};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +19,7 @@ use tendermint_proto::types::evidence::Sum;
 use tendermint_proto::types::CommitSig;
 use tendermint_proto::types::EvidenceList as RawEvidenceList;
 use tracing::{info, instrument};
+use sqlx::Row as TRow;
 
 use crate::{
     DB_SAVE_BLOCK_COUNTER, DB_SAVE_BLOCK_DURATION, DB_SAVE_COMMIT_SIG_DURATION,
@@ -254,6 +255,7 @@ impl Database {
         Self::save_transactions(
             block.data.as_ref(),
             &block_id,
+            block.header.height.value(),
             checksums_map,
             sqlx_tx,
             network,
@@ -527,6 +529,7 @@ impl Database {
     async fn save_transactions<'a>(
         txs: &Vec<Vec<u8>>,
         block_id: &[u8],
+        block_height: u64,
         checksums_map: &HashMap<String, String>,
         sqlx_tx: &mut Transaction<'a, sqlx::Postgres>,
         network: &str,
@@ -553,6 +556,7 @@ impl Database {
                     hash, 
                     block_id, 
                     tx_type,
+                    wrapper_id,
                     fee_amount_per_gas_unit,
                     fee_token,
                     gas_limit_multiplier,
@@ -570,12 +574,22 @@ impl Database {
         // being 8 the number of columns.
         let mut tx_values = Vec::with_capacity(txs.len());
 
+        let mut i: usize = 0;
         for t in txs.iter() {
             let tx = proto::Tx::try_from(t.as_slice()).map_err(|_| Error::InvalidTxData)?;
             let mut code = Default::default();
+            let mut txid_wrapper: Vec<u8> = vec![];
 
             // Decrypted transaction give access to the raw data
             if let TxType::Decrypted(..) = tx.header().tx_type {
+
+                // look for wrapper tx to link to
+                let txs = query(&format!("SELECT * FROM {0}.transactions WHERE block_id IN (SELECT block_id FROM {0}.blocks WHERE header_height = {1});", network, block_height-1))
+                    .fetch_all(&mut *sqlx_tx)
+                    .await?;
+                txid_wrapper = txs[i].try_get("hash")?;
+                i += 1;
+
                 code = tx
                     .get_section(tx.code_sechash())
                     .and_then(|s| s.code_sec())
@@ -757,6 +771,7 @@ impl Database {
                 tx.header_hash().0.as_slice().to_vec(),
                 block_id.to_vec(),
                 utils::tx_type_name(&tx.header.tx_type),
+                txid_wrapper,
                 fee_amount_per_gas_unit,
                 fee_token,
                 gas_limit_multiplier,
@@ -779,6 +794,7 @@ impl Database {
                     hash,
                     block_id,
                     tx_type,
+                    wrapper_id,
                     fee_amount_per_gas_unit,
                     fee_token,
                     fee_gas_limit_multiplier,
@@ -788,6 +804,7 @@ impl Database {
                     b.push_bind(hash)
                         .push_bind(block_id)
                         .push_bind(tx_type)
+                        .push_bind(wrapper_id)
                         .push_bind(fee_amount_per_gas_unit)
                         .push_bind(fee_token)
                         .push_bind(fee_gas_limit_multiplier as i64)

--- a/src/database.rs
+++ b/src/database.rs
@@ -10,7 +10,8 @@ use namada::types::{
     transaction::{self, account::UpdateAccount, pgf::UpdateStewardCommission, TxType},
 };
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow as Row};
-use sqlx::{query, QueryBuilder, Transaction, Executor};
+use sqlx::Row as TRow;
+use sqlx::{query, Executor, QueryBuilder, Transaction};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +20,6 @@ use tendermint_proto::types::evidence::Sum;
 use tendermint_proto::types::CommitSig;
 use tendermint_proto::types::EvidenceList as RawEvidenceList;
 use tracing::{info, instrument};
-use sqlx::Row as TRow;
 
 use crate::{
     DB_SAVE_BLOCK_COUNTER, DB_SAVE_BLOCK_DURATION, DB_SAVE_COMMIT_SIG_DURATION,
@@ -582,7 +582,6 @@ impl Database {
 
             // Decrypted transaction give access to the raw data
             if let TxType::Decrypted(..) = tx.header().tx_type {
-
                 // look for wrapper tx to link to
                 let txs = query(&format!("SELECT * FROM {0}.transactions WHERE block_id IN (SELECT block_id FROM {0}.blocks WHERE header_height = {1});", network, block_height-1))
                     .fetch_all(&mut *sqlx_tx)

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -35,6 +35,7 @@ pub fn get_create_transactions_table_query(network: &str) -> String {
         hash BYTEA NOT NULL,
         block_id BYTEA NOT NULL,
         tx_type TEXT NOT NULL,
+        wrapper_id BYTEA,
         fee_amount_per_gas_unit TEXT,
         fee_token TEXT,
         gas_limit_multiplier BIGINT,


### PR DESCRIPTION
closes #34 

This add the previous wrapper tx id to all decrypted id in the transaction table.

