### PR TITLE
fix: do proper lookup for event keys for transaction status

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -635,13 +635,13 @@ impl Database {
 
                 // Look for the reurn code associated to the tx
                 for event in end_events {
-                    for attr in event.attributes {
+                    for attr in event.attributes.iter() {
                         // We look to confirm hash of transaction
                         if attr.key == "hash"
                             && attr.value.to_ascii_lowercase() == hex::encode(&hash_id)
                         {
                             // Now we look for the return code
-                            for attr in event.attributes {
+                            for attr in event.attributes.iter() {
                                 if attr.key == "code" {
                                     // using unwrap here is ok because we assume it is always going to be a number unless there is a bug in the node
                                     return_code = Some(attr.value.parse().unwrap());

--- a/src/database.rs
+++ b/src/database.rs
@@ -646,11 +646,9 @@ impl Database {
                                     // using unwrap here is ok because we assume it is always going to be a number unless there is a bug in the node
                                     return_code = Some(attr.value.parse().unwrap());
                                 }
-
                             }
                         }
                     }
-
                 }
 
                 // look for wrapper tx to link to

--- a/src/database.rs
+++ b/src/database.rs
@@ -635,13 +635,22 @@ impl Database {
 
                 // Look for the reurn code associated to the tx
                 for event in end_events {
-                    // we assume it will always be in this order
-                    if event.attributes[5].key == "hash"
-                        && event.attributes[5].value.to_ascii_lowercase() == hex::encode(&hash_id)
-                    {
-                        // using unwrap here is ok because we assume it is always going to be a number unless there is a bug in the node
-                        return_code = Some(event.attributes[0].value.parse().unwrap());
+                    for attr in event.attributes {
+                        // We look to confirm hash of transaction
+                        if attr.key == "hash"
+                            && attr.value.to_ascii_lowercase() == hex::encode(&hash_id)
+                        {
+                            // Now we look for the return code
+                            for attr in event.attributes {
+                                if attr.key == "code" {
+                                    // using unwrap here is ok because we assume it is always going to be a number unless there is a bug in the node
+                                    return_code = Some(attr.value.parse().unwrap());
+                                }
+
+                            }
+                        }
                     }
+
                 }
 
                 // look for wrapper tx to link to


### PR DESCRIPTION
closes #59 

This PR add a proper look up for the `code` event attributes to determine if the transaction has been successful. We used to assume the order wouldn't changed but it was reported in issue #59 that it changes.