### PR TITLE
Argument parsing via cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,10 +119,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -957,28 +999,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clru"
@@ -1040,6 +1097,12 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "config"
@@ -1691,7 +1754,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2703,7 +2766,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3108,7 +3171,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3559,7 +3622,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3728,6 +3791,7 @@ dependencies = [
  "axum-prometheus",
  "borsh 0.9.4",
  "bytes",
+ "clap",
  "config",
  "criterion",
  "futures",
@@ -4282,7 +4346,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5139,7 +5203,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5327,7 +5391,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5670,7 +5734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5851,6 +5915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5976,7 +6046,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6348,7 +6418,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.3",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6763,6 +6833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7032,7 +7108,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7041,7 +7117,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7050,13 +7135,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -7066,10 +7166,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7078,10 +7190,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7090,16 +7214,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
@@ -7117,7 +7259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ metrics-exporter-prometheus = {version = "0.12.1", optional = true}
 tendermint = "0.33.0"
 tendermint-rpc = { version = "0.33.0", features = ["http-client"], default-features = false}
 tendermint-proto = "0.33.0"
+clap = { version = "4.4.2", features = ["derive", "env"] }
 
 [patch.crates-io]
 borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,19 +9,15 @@ const ENV_VAR_NAME: &str = "INDEXER_CONFIG_PATH";
 
 pub const SERVER_ADDR: &str = "127.0.0.1";
 pub const SERVER_PORT: u16 = 30303;
-pub const SERVER_PORT_STR: &str = "30303";
 
 pub const TENDERMINT_ADDR: &str = "http://127.0.0.1";
 pub const INDEXER_PORT: u16 = 26657;
-pub const INDEXER_PORT_STR: &str = "26657";
 
 pub const JAEGER_HOST: &str = "localhost";
 pub const JAEGER_PORT: u16 = 6831;
-pub const JAEGER_PORT_STR: &str = "6831";
 
 pub const PROMETHEUS_HOST: &str = "localhost";
 pub const PROMETHEUS_PORT: u16 = 9000;
-pub const PROMETHEUS_PORT_STR: &str = "9000";
 
 pub const DEFAULT_NETWORK: &str = "public-testnet-14";
 
@@ -130,7 +126,7 @@ pub struct CliSettings {
     pub network: String,
     #[clap(long, env, default_value = SERVER_ADDR)]
     pub server_serve_at: String,
-    #[clap(long, env, default_value = SERVER_PORT_STR)]
+    #[clap(long, env, default_value_t = SERVER_PORT)]
     pub server_port: u16,
     #[clap(long, env, default_value = "localhost")]
     pub database_host: String,
@@ -144,17 +140,17 @@ pub struct CliSettings {
     pub database_connection_timeout: Option<u64>,
     #[clap(long, env, default_value = TENDERMINT_ADDR)]
     pub indexer_tendermint_addr: String,
-    #[clap(long, env, default_value = INDEXER_PORT_STR)]
+    #[clap(long, env, default_value_t = INDEXER_PORT)]
     pub indexer_port: u16,
     #[clap(long, env, action=ArgAction::SetFalse)]
     pub jaeger_enable: bool,
     #[clap(long, env, default_value = JAEGER_HOST)]
     pub jaeger_host: String,
-    #[clap(long, env, default_value = JAEGER_PORT_STR)]
+    #[clap(long, env, default_value_t = JAEGER_PORT)]
     pub jaeger_port: u16,
     #[clap(long, env, default_value = PROMETHEUS_HOST)]
     pub prometheus_host: String,
-    #[clap(long, env, default_value = PROMETHEUS_PORT_STR)]
+    #[clap(long, env, default_value_t = PROMETHEUS_PORT)]
     pub prometheus_port: u16,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use clap::{ArgAction, Parser};
 use config::{Config, File};
 use serde::Deserialize;
 use std::{env, net::SocketAddr};
@@ -8,15 +9,19 @@ const ENV_VAR_NAME: &str = "INDEXER_CONFIG_PATH";
 
 pub const SERVER_ADDR: &str = "127.0.0.1";
 pub const SERVER_PORT: u16 = 30303;
+pub const SERVER_PORT_STR: &str = "30303";
 
 pub const TENDERMINT_ADDR: &str = "http://127.0.0.1";
 pub const INDEXER_PORT: u16 = 26657;
+pub const INDEXER_PORT_STR: &str = "26657";
 
 pub const JAEGER_HOST: &str = "localhost";
 pub const JAEGER_PORT: u16 = 6831;
+pub const JAEGER_PORT_STR: &str = "6831";
 
 pub const PROMETHEUS_HOST: &str = "localhost";
 pub const PROMETHEUS_PORT: u16 = 9000;
+pub const PROMETHEUS_PORT_STR: &str = "9000";
 
 pub const DEFAULT_NETWORK: &str = "public-testnet-14";
 
@@ -117,6 +122,42 @@ impl Default for DatabaseConfig {
     }
 }
 
+#[derive(Debug, Deserialize, clap::Parser)]
+pub struct CliSettings {
+    #[clap(long, env, default_value = "")]
+    pub log_level: String,
+    #[clap(long, env, default_value = DEFAULT_NETWORK)]
+    pub network: String,
+    #[clap(long, env, default_value = SERVER_ADDR)]
+    pub server_serve_at: String,
+    #[clap(long, env, default_value = SERVER_PORT_STR)]
+    pub server_port: u16,
+    #[clap(long, env, default_value = "localhost")]
+    pub database_host: String,
+    #[clap(long, env, default_value = "postgres")]
+    pub database_user: String,
+    #[clap(long, env, default_value = "wow")]
+    pub database_password: String,
+    #[clap(long, env, default_value = "blockchain")]
+    pub database_dbname: String,
+    #[clap(long, env)]
+    pub database_connection_timeout: Option<u64>,
+    #[clap(long, env, default_value = TENDERMINT_ADDR)]
+    pub indexer_tendermint_addr: String,
+    #[clap(long, env, default_value = INDEXER_PORT_STR)]
+    pub indexer_port: u16,
+    #[clap(long, env, action=ArgAction::SetFalse)]
+    pub jaeger_enable: bool,
+    #[clap(long, env, default_value = JAEGER_HOST)]
+    pub jaeger_host: String,
+    #[clap(long, env, default_value = JAEGER_PORT_STR)]
+    pub jaeger_port: u16,
+    #[clap(long, env, default_value = PROMETHEUS_HOST)]
+    pub prometheus_host: String,
+    #[clap(long, env, default_value = PROMETHEUS_PORT_STR)]
+    pub prometheus_port: u16,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub log_level: String,
@@ -138,6 +179,39 @@ impl Default for Settings {
             indexer: Default::default(),
             jaeger: Default::default(),
             prometheus: Default::default(),
+        }
+    }
+}
+
+impl From<CliSettings> for Settings {
+    fn from(value: CliSettings) -> Self {
+        Self {
+            log_level: value.log_level,
+            network: value.network,
+            database: DatabaseConfig {
+                host: value.database_host,
+                user: value.database_user,
+                password: value.database_password,
+                dbname: value.database_dbname,
+                connection_timeout: value.database_connection_timeout,
+            },
+            server: ServerConfig {
+                serve_at: value.server_serve_at,
+                port: value.server_port,
+            },
+            indexer: IndexerConfig {
+                tendermint_addr: value.indexer_tendermint_addr,
+                port: value.indexer_port,
+            },
+            jaeger: JaegerConfig {
+                enable: value.jaeger_enable,
+                host: value.jaeger_host,
+                port: value.jaeger_port,
+            },
+            prometheus: PrometheusConfig {
+                host: value.prometheus_host,
+                port: value.prometheus_port,
+            },
         }
     }
 }
@@ -164,7 +238,10 @@ impl Settings {
             return Ok(settings);
         }
 
-        Ok(Self::default())
+        let cli_settings = CliSettings::parse();
+        let settings = Settings::from(cli_settings);
+
+        Ok(settings)
     }
 
     pub fn server_config(&self) -> &ServerConfig {


### PR DESCRIPTION
If no `toml` path is passed set via `INDEXER_CONFIG_PATH` try to parse the arguments from cli.