### PR TITLE
fix: vote_proposal_id not a primary key

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -206,6 +206,6 @@ pub fn get_create_delegations_table(network: &str) -> String {
         vote_proposal_id BYTEA,
         delegator_id TEXT NOT NULL
     );",
-        network, network
+        network
     )
 }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -185,7 +185,7 @@ pub fn get_create_vote_proposal_table(network: &str) -> String {
     // a reference for the delegations table.
     format!(
         "CREATE TABLE IF NOT EXISTS {}.vote_proposal (
-        vote_proposal_id BYTEA NOT NULL PRIMARY KEY,
+        vote_proposal_id BYTEA,
         vote BOOL NOT NULL,
         vote_default BOOL NOT NULL,
         voter TEXT NOT NULL,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -203,7 +203,7 @@ pub fn get_create_delegations_table(network: &str) -> String {
     format!(
         "CREATE TABLE IF NOT EXISTS {}.delegations (
         id SERIAL,
-        vote_proposal_id BYTEA REFERENCES {}.vote_proposal(vote_proposal_id),
+        vote_proposal_id BYTEA,
         delegator_id TEXT NOT NULL
     );",
         network, network

--- a/tests/save_block.rs
+++ b/tests/save_block.rs
@@ -33,7 +33,6 @@ mod save_block {
                 .unwrap();
         }
 
-        // assert!(db.create_indexes().await.is_ok());
         db.create_indexes()
             .await
             .expect("Something went wrong creating database indexes");


### PR DESCRIPTION
closes #79 
closes #82 

We remove the constraint on `vote_proposal_id` to avoid error and have a better syncing result.