### PR TITLE
Remove legacy check

### DIFF
--- a/src/server/blocks.rs
+++ b/src/server/blocks.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use tracing::{error, instrument, trace};
+use tracing::{instrument, trace};
 
 use sqlx::postgres::PgRow as Row;
 use sqlx::Row as TRow;
@@ -16,10 +16,6 @@ use tendermint::{
 
 use super::{from_hex, serialize_hex};
 use crate::error::Error;
-
-// represents the number of BlockInfo fields
-// that were stored in database.
-const NUM_BLOCK_HEADER_FIELDS: usize = 23;
 
 /// Last commit info in a block
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -114,11 +110,6 @@ impl TryFrom<&Row> for BlockInfo {
 
     #[instrument(level = "trace", skip(row))]
     fn try_from(row: &Row) -> Result<Self, Self::Error> {
-        if row.len() != NUM_BLOCK_HEADER_FIELDS {
-            error!("Invalid block data, empty Row");
-            return Err(Error::InvalidBlockData);
-        }
-
         // block_id
         let block_id: Vec<u8> = row.try_get("block_id")?;
         trace!("parsed block_id {:?}", &block_id);

--- a/src/server/tx.rs
+++ b/src/server/tx.rs
@@ -24,17 +24,12 @@ use prost::Message;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::{error, info};
+use tracing::info;
 
 use super::utils::serialize_optional_hex;
 
 use sqlx::postgres::PgRow as Row;
 use sqlx::Row as TRow;
-
-// represents the number of columns
-// that db must contains in order to deserialized
-// transactions
-const NUM_TX_COLUMNS: usize = 10;
 
 // namada::ibc::applications::transfer::msgs::transfer::TYPE_URL has been made private and can't be access anymore
 const MSG_TRANSFER_TYPE_URL: &str = "/ibc.applications.transfer.v1.MsgTransfer";
@@ -189,11 +184,6 @@ impl TryFrom<Row> for TxInfo {
 
     fn try_from(row: Row) -> Result<Self, Self::Error> {
         info!("TxInfo::try_from");
-
-        if row.len() != NUM_TX_COLUMNS {
-            error!("Wrong number of colums in row");
-            return Err(Error::InvalidTxData);
-        }
 
         let hash: Vec<u8> = row.try_get("hash")?;
         let block_id: Vec<u8> = row.try_get("block_id")?;


### PR DESCRIPTION
Remove the legacy check that was used to avoid panics when retrieving data from block and tx tables.
current code will error if the requested column does not exist.for number of columns in table