### PR TITLE
Clarify users that a create_index field is needed in the Settings.toml file

### DIFF
--- a/config/Settings.example.toml
+++ b/config/Settings.example.toml
@@ -9,7 +9,7 @@ dbname = "blockchain"
 # Optional field to configure a timeout if database connection 
 # fails.
 connection_timeout = 20
-
+create_index = true
 
 [server]
 serve_at = "0.0.0.0"

--- a/docs/03-indexer.md
+++ b/docs/03-indexer.md
@@ -17,6 +17,7 @@ host = "localhost"
 user = "postgres"
 password = "wow"
 dbname = "blockchain"
+create_index = true
 
 # The tendermint RPC address and port to access the Namada node
 [indexer]


### PR DESCRIPTION
This is a clarification on how to fix the issue explained in #95.