### PR TITLE
checksum for shielded-expedition is v0.31.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-NAMADA_VERSION := 0.31.0
+NAMADA_VERSION := 0.31.1
 BASE_URL := https://raw.githubusercontent.com/anoma/namada
 URL := $(BASE_URL)/v$(NAMADA_VERSION)/wasm/checksums.json
 


### PR DESCRIPTION
change version to download the appropriate checksum (changed to v0.31.1 for the shielded-expedition network)