### PR TITLE
fix: update doc and setting example to add port value

### DIFF
--- a/config/Settings.example.toml
+++ b/config/Settings.example.toml
@@ -6,6 +6,7 @@ host = "localhost"
 user = "postgres"
 password = "wow"
 dbname = "blockchain"
+port = 5432
 # Optional field to configure a timeout if database connection 
 # fails.
 connection_timeout = 20

--- a/docs/04-server.md
+++ b/docs/04-server.md
@@ -16,7 +16,9 @@ host = "localhost"
 user = "postgres"
 password = "wow"
 dbname = "blockchain"
-
+port = 5432
+connection_timeout = 20 # Optional timeout value
+create_index = true
 
 [server]
 serve_at = "0.0.0.0"


### PR DESCRIPTION
Added to the Setting.example.toml file and the doc the change for the database port. It is now configurable and should be added in the config file.