### PR TITLE
Fix: 'Invalid Transaction data' error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,8 +3683,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "namada_account"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3695,8 +3695,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -3740,8 +3740,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "ethabi",
@@ -3769,8 +3769,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3780,8 +3780,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3797,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "ibc",
@@ -3820,8 +3820,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3830,8 +3830,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "eyre",
@@ -3844,8 +3844,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3856,8 +3856,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3877,8 +3877,8 @@ dependencies = [
 
 [[package]]
 name = "namada_sdk"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3935,8 +3935,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "masp_primitives",
  "namada_core",
@@ -3949,8 +3949,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "ics23",
@@ -3971,8 +3971,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "itertools 0.10.5",
@@ -3986,8 +3986,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "namada_core",
  "namada_shielded_token",
@@ -3997,8 +3997,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "namada_core",
  "namada_storage",
@@ -4006,8 +4006,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "ark-bls12-381",
  "borsh",
@@ -4028,8 +4028,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.31.0"
-source = "git+https://github.com/anoma/namada?rev=v0.31.0#720304bc49aec3390f9bf127b69cd1e875612fc4"
+version = "0.31.4"
+source = "git+https://github.com/anoma/namada?rev=v0.31.4#5901dcb571779c43668ddf58c30261f8e5add428"
 dependencies = [
  "borsh",
  "namada_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/indexer.rs"
 [dependencies]
 getrandom = { version = "0.2" }
 async-trait = "0.1.51"
-namada_sdk = { git = "https://github.com/anoma/namada", rev = "v0.31.0" }
+namada_sdk = { git = "https://github.com/anoma/namada", rev = "v0.31.4" }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 tokio = { version = "1.26.0", features = ["rt-multi-thread"] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -17,7 +17,6 @@ use namada_sdk::{
     },
     types::{
         address::Address,
-        eth_bridge_pool::PendingTransfer,
         // key::PublicKey,
         token,
     },
@@ -646,14 +645,8 @@ impl Database {
                     .ok_or(Error::InvalidTxData)?;
 
                 let code_hex = hex::encode(code.as_slice());
-
-                dbg!(hex::encode(&hash_id));
-                dbg!(hex::encode(&code));
-                dbg!(&tx.sections[0].data());
-
                 let unknown_type = "unknown".to_string();
                 let type_tx = checksums_map.get(&code_hex).unwrap_or(&unknown_type);
-                dbg!(&type_tx);
                 let mut data: Vec<u8> = vec![];
                 if type_tx != "tx_bridge_pool" {
                     // "tx_bridge_pool" doesn't have their data in the data section anymore ?

--- a/src/database.rs
+++ b/src/database.rs
@@ -165,7 +165,7 @@ impl Database {
 
     /// Inner implementation that uses a postgres-transaction
     /// to ensure database coherence.
-    #[instrument(skip(block, checksums_map, sqlx_tx))]
+    #[instrument(skip(block, block_results, checksums_map, sqlx_tx))]
     async fn save_block_impl<'a>(
         block: &Block,
         block_results: &block_results::Response,
@@ -275,7 +275,7 @@ impl Database {
     }
 
     /// Save a block and commit database
-    #[instrument(skip(self, block, checksums_map))]
+    #[instrument(skip(self, block, block_results, checksums_map))]
     pub async fn save_block(
         &self,
         block: &Block,
@@ -423,7 +423,7 @@ impl Database {
     /// It is up to the caller to commit the operation.
     /// this method is meant to be used when caller is saving
     /// many blocks, and can commit after it.
-    #[instrument(skip(block, checksums_map, sqlx_tx, network))]
+    #[instrument(skip(block, block_results, checksums_map, sqlx_tx, network))]
     pub async fn save_block_tx<'a>(
         block: &Block,
         block_results: &block_results::Response,
@@ -543,7 +543,7 @@ impl Database {
     /// Save all the transactions in txs, it is up to the caller to
     /// call sqlx_tx.commit().await?; for the changes to take place in
     /// database.
-    #[instrument(skip(txs, block_id, sqlx_tx, checksums_map, network))]
+    #[instrument(skip(txs, block_id, sqlx_tx, checksums_map, block_results, network))]
     async fn save_transactions<'a>(
         txs: &[Vec<u8>],
         block_id: &[u8],
@@ -647,9 +647,18 @@ impl Database {
 
                 let code_hex = hex::encode(code.as_slice());
 
+                dbg!(hex::encode(&hash_id));
+                dbg!(hex::encode(&code));
+                dbg!(&tx.sections[0].data());
+
                 let unknown_type = "unknown".to_string();
                 let type_tx = checksums_map.get(&code_hex).unwrap_or(&unknown_type);
-                let data = tx.data().ok_or(Error::InvalidTxData)?;
+                dbg!(&type_tx);
+                let mut data: Vec<u8> = vec![];
+                if type_tx != "tx_bridge_pool" {
+                    // "tx_bridge_pool" doesn't have their data in the data section anymore ?
+                    data = tx.data().ok_or(Error::InvalidTxData)?;
+                }
 
                 info!("Saving {} transaction", type_tx);
 
@@ -740,36 +749,36 @@ impl Database {
                         query.execute(&mut *sqlx_tx).await?;
                     }
                     // this is an ethereum transaction
-                    "tx_bridge_pool" => {
-                        // Only TransferToEthereum type is supported at the moment by namada and us.
-                        let tx_bridge = PendingTransfer::try_from_slice(&data[..])?;
+                    // "tx_bridge_pool" => {
+                    //     // Only TransferToEthereum type is supported at the moment by namada and us.
+                    //     let tx_bridge = PendingTransfer::try_from_slice(&data[..])?;
 
-                        let mut query_builder: QueryBuilder<_> = QueryBuilder::new(format!(
-                            "INSERT INTO {}.tx_bridge_pool(
-                                tx_id,
-                                asset,
-                                recipient,
-                                sender,
-                                amount,
-                                gas_amount,
-                                payer
-                            )",
-                            network
-                        ));
+                    //     let mut query_builder: QueryBuilder<_> = QueryBuilder::new(format!(
+                    //         "INSERT INTO {}.tx_bridge_pool(
+                    //             tx_id,
+                    //             asset,
+                    //             recipient,
+                    //             sender,
+                    //             amount,
+                    //             gas_amount,
+                    //             payer
+                    //         )",
+                    //         network
+                    //     ));
 
-                        let query = query_builder
-                            .push_values(std::iter::once(0), |mut b, _| {
-                                b.push_bind(&hash_id)
-                                    .push_bind(tx_bridge.transfer.asset.to_string())
-                                    .push_bind(tx_bridge.transfer.recipient.to_string())
-                                    .push_bind(tx_bridge.transfer.sender.to_string())
-                                    .push_bind(tx_bridge.transfer.amount.to_string_native())
-                                    .push_bind(tx_bridge.gas_fee.amount.to_string_native())
-                                    .push_bind(tx_bridge.gas_fee.payer.to_string());
-                            })
-                            .build();
-                        query.execute(&mut *sqlx_tx).await?;
-                    }
+                    //     let query = query_builder
+                    //         .push_values(std::iter::once(0), |mut b, _| {
+                    //             b.push_bind(&hash_id)
+                    //                 .push_bind(tx_bridge.transfer.asset.to_string())
+                    //                 .push_bind(tx_bridge.transfer.recipient.to_string())
+                    //                 .push_bind(tx_bridge.transfer.sender.to_string())
+                    //                 .push_bind(tx_bridge.transfer.amount.to_string_native())
+                    //                 .push_bind(tx_bridge.gas_fee.amount.to_string_native())
+                    //                 .push_bind(tx_bridge.gas_fee.payer.to_string());
+                    //         })
+                    //         .build();
+                    //     query.execute(&mut *sqlx_tx).await?;
+                    // }
                     "tx_vote_proposal" => {
                         let mut query_builder: QueryBuilder<_> = QueryBuilder::new(format!(
                             "INSERT INTO {}.vote_proposal(


### PR DESCRIPTION
We have an error when trying to get the data in some cases of bridge transactions. We will not try to decode it anymore to avoid raising the error and just save the encoded data.