### PR TITLE
Add reason string to InvalidTxData error.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,8 @@ use tokio::sync::mpsc::error::SendError;
 pub enum Error {
     #[error("Invalid Block data")]
     InvalidBlockData,
-    #[error("Invalid Transaction data")]
-    InvalidTxData,
+    #[error("Invalid Transaction data (reason: {0})")]
+    InvalidTxData(String),
     #[error("Tendermint error: {0}")]
     TendermintError(#[from] TError),
     #[error("Tendermint rpc_error: {0}")]
@@ -71,7 +71,7 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let status = match self {
             Error::InvalidBlockData => StatusCode::EXPECTATION_FAILED,
-            Error::InvalidTxData => StatusCode::EXPECTATION_FAILED,
+            Error::InvalidTxData(_) => StatusCode::EXPECTATION_FAILED,
             Error::DB(_) => StatusCode::NOT_FOUND,
             Error::HexError(_) => StatusCode::BAD_REQUEST,
             Error::TendermintError(_) => StatusCode::EXPECTATION_FAILED,


### PR DESCRIPTION
There are several different places where `Error::InvalidTxData` can be produced; this adds a `String` value to it so that every place that results in this error can also provide a helpful explanation.
