### PR TITLE
Add support for json logging.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6949,6 +6949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6958,12 +6968,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bytes = "1.0"
 time = "0.3"
 tracing-subscriber = { version = "0.3.17", features = [
     "fmt",
+    "json",
     "std",
     "env-filter",
 ] }

--- a/config/Settings.example.toml
+++ b/config/Settings.example.toml
@@ -1,4 +1,5 @@
 log_level = "info"
+log_format = "pretty"
 network = "public-testnet-15"
 
 [database]

--- a/contrib/helm/indexer-values.yaml
+++ b/contrib/helm/indexer-values.yaml
@@ -64,6 +64,7 @@ configMap:
     settings:
       Settings.toml: |
         log_level = "info"
+        log_format = "json"
         network = "public-testnet-14"
     
         [database]

--- a/contrib/helm/server-values.yaml
+++ b/contrib/helm/server-values.yaml
@@ -65,6 +65,7 @@ configMap:
     settings:
       Settings.toml: |
         log_level = "info"
+        log_format = "json"
         network = "public-testnet-14"
         
         [database]

--- a/docs/03-indexer.md
+++ b/docs/03-indexer.md
@@ -8,8 +8,9 @@ The indexer must have the following configuration:
 
 Settings.toml
 ```toml
-# Level of logging in the indexer
+# Level and format of logging in the indexer
 log_level = "info"
+log_format = "pretty" # optional; either "pretty" or "json"
 network = "public-testnet-15" # IMPORANT! Do not use `.` just put the name of the network and don't have the hash (e.g 'shielded-expedition.b40d8e9055' becomes 'shielded-expedition')
 
 # Connection information for the PostgreSQL database

--- a/docs/04-server.md
+++ b/docs/04-server.md
@@ -8,6 +8,7 @@ Settings.toml
 
 ```toml
 log_level = "info"
+log_format = "pretty" # optional; either "pretty" or "json"
 network = "public-testnet-15" # IMPORANT! Do not use `.` just put the name of the network and don't have the hash (e.g 'shielded-expedition.b40d8e9055' becomes 'shielded-expedition')
 
 # Connection information for the PostgreSQL database

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub const PROMETHEUS_PORT: u16 = 9000;
 
 pub const DEFAULT_NETWORK: &str = "public-testnet-15";
 
+pub const DEFAULT_LOG_FORMAT: &str = "pretty";
+
 #[derive(Debug, Deserialize)]
 pub struct IndexerConfig {
     pub tendermint_addr: String,
@@ -125,10 +127,20 @@ impl Default for DatabaseConfig {
     }
 }
 
+#[derive(Debug, Default, Deserialize, Clone, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogFormat {
+    Json,
+    #[default]
+    Pretty,
+}
+
 #[derive(Debug, Deserialize, clap::Parser)]
 pub struct CliSettings {
     #[clap(long, env, default_value = "")]
     pub log_level: String,
+    #[clap(long, env, default_value = DEFAULT_LOG_FORMAT)]
+    pub log_format: LogFormat,
     #[clap(long, env, default_value = DEFAULT_NETWORK)]
     pub network: String,
     #[clap(long, env, default_value = SERVER_ADDR)]
@@ -166,6 +178,8 @@ pub struct CliSettings {
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub log_level: String,
+    #[serde(default)]
+    pub log_format: LogFormat,
     pub network: String,
     pub database: DatabaseConfig,
     pub server: ServerConfig,
@@ -178,6 +192,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             log_level: Default::default(),
+            log_format: Default::default(),
             network: DEFAULT_NETWORK.to_string(),
             database: Default::default(),
             server: Default::default(),
@@ -192,6 +207,7 @@ impl From<CliSettings> for Settings {
     fn from(value: CliSettings) -> Self {
         Self {
             log_level: value.log_level,
+            log_format: value.log_format,
             network: value.network,
             database: DatabaseConfig {
                 host: value.database_host,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@ pub mod tables;
 mod telemetry;
 pub mod utils;
 
-pub use crate::config::{IndexerConfig, JaegerConfig, PrometheusConfig, ServerConfig, Settings};
+pub use crate::config::{
+    IndexerConfig, JaegerConfig, LogFormat, PrometheusConfig, ServerConfig, Settings,
+};
 pub use database::Database;
 pub use error::Error;
 pub use indexer::start_indexing;


### PR DESCRIPTION
This introduces a new _optional_ config option `log_format` which can be either `"pretty"` (the default) or `"json"`.

When using `log_format = "json"` the logs will look like this:

```
{"timestamp":"2024-02-15T23:55:08.209893Z","level":"INFO","fields":{"message":"Starting database connection"},"target":"indexer"}
{"timestamp":"2024-02-15T23:55:08.307973Z","level":"INFO","fields":{"message":"Creating tables"},"target":"indexer"}
{"timestamp":"2024-02-15T23:55:08.308131Z","level":"INFO","fields":{"message":"Creating tables if they don't exist"},"target":"namadexer::database","span":{"name":"create_tables"},"spans":[{"name":"create_tables"}]}
{"timestamp":"2024-02-15T23:55:08.413702Z","level":"INFO","fields":{"message":"Starting indexer"},"target":"indexer"}
{"timestamp":"2024-02-15T23:55:08.413765Z","level":"INFO","fields":{"message":"***** Starting indexer *****"},"target":"namadexer::indexer"}
{"timestamp":"2024-02-15T23:55:08.418843Z","level":"INFO","fields":{"message":"Starting at height : 23688"},"target":"namadexer::indexer"}
{"timestamp":"2024-02-15T23:55:08.422336Z","level":"INFO","fields":{"message":"We already have indexes created resuming from last block indexed"},"target":"namadexer::indexer::utils","span":{"name":"Utils::has_indexes"},"spans":[{"name":"Utils::has_indexes"}]}
```
