### PR TITLE
Do not set INDEXER_CONFIG_PATH by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ COPY --from=builder /usr/src/namadexer/checksums.json /app
 
 RUN apt-get update && rm -rf /var/lib/apt/lists/*
 
-# default env
-ENV RUST_LOG "namadexer=debug"
-
 # if you wish to run with a config file, mount it at /app/config/Settings.toml
 # and set the env variable INDEXER_CONFIG_PATH to /app/config/Settings.toml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ COPY --from=builder /usr/src/namadexer/checksums.json /app
 RUN apt-get update && rm -rf /var/lib/apt/lists/*
 
 # default env
-ENV INDEXER_CONFIG_PATH "/app/config/Settings.toml"
 ENV RUST_LOG "namadexer=debug"
+
+# if you wish to run with a config file, mount it at /app/config/Settings.toml
+# and set the env variable INDEXER_CONFIG_PATH to /app/config/Settings.toml
 
 CMD indexer


### PR DESCRIPTION
This allows the docker image to be configured via env variables instead of a config file. (When `INDEXER_CONFIG_PATH` is set, the application will only use the file and will not attempt to read its config from env vars.) This is useful for environments like Google Cloud Run where it is simpler to set env vars than to mount a file into the container.
