### PR TITLE
fix: added a timeout 

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tracing::{info, instrument};
-
+use tokio::time::timeout;
 use crate::config::IndexerConfig;
 use crate::utils::load_checksums;
 
@@ -47,7 +47,7 @@ async fn get_block(block_height: u32, client: &HttpClient) -> (Block, block_resu
         let dur = instant.elapsed();
 
         match response {
-            Ok(resp) => {
+            Ok(resp) => {   
                 info!("Got block {}", block_height);
                 let labels = [(
                     "indexer_get_block: ",
@@ -156,7 +156,7 @@ fn blocks_stream(
     block: u64,
     client: &HttpClient,
 ) -> impl Stream<Item = (Block, block_results::Response)> + '_ {
-    futures::stream::iter(block..).then(move |i| async move { get_block(i as u32, client).await })
+    futures::stream::iter(block..).then(move |i| async move { timeout(Duration::from_secs(30), get_block(i as u32, client)).await.unwrap() })
 }
 
 /// Start the indexer service blocking current thread.


### PR DESCRIPTION
Added a temp solution for the timeout issue. This PR add a timeout of 30secs which will lead to the indexer to crash if it doesn't get an answer from the RPC-JSON.

This is temp until the https://github.com/informalsystems/tendermint-rs/pull/1380 is merged in lib.