### PR TITLE
fix: patch the last commit empty error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6464,8 +6464,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f8a10105d0a7c4af0a242e23ed5a12519afe5cc0e68419da441bb5981a6802"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?branch=romac/allow-misformed-block#3b9f94e48e140197b9ec137cd5dfb99510438a1b"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -6507,8 +6506,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6bf36c613bb113737c333e3c1d6dfd3c99f8ac679e84feb58dd6456d77fb2e"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?branch=romac/allow-misformed-block#3b9f94e48e140197b9ec137cd5dfb99510438a1b"
 dependencies = [
  "flex-error",
  "serde",
@@ -6552,8 +6550,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff525d5540a9fc535c38dc0d92a98da3ee36fcdfbda99cecb9f3cce5cd4d41d7"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?branch=romac/allow-misformed-block#3b9f94e48e140197b9ec137cd5dfb99510438a1b"
 dependencies = [
  "bytes",
  "flex-error",
@@ -6598,8 +6595,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8fe61b1772cd50038bdeeadf53773bb37a09e639dd8e6d996668fd220ddb29"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?branch=romac/allow-misformed-block#3b9f94e48e140197b9ec137cd5dfb99510438a1b"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/indexer.rs"
 getrandom = { version = "0.2" }
 async-trait = "0.1.51"
 namada_sdk = { git = "https://github.com/anoma/namada", rev = "v0.31.4" }
+#namada_sdk_32 = { package = "namada_sdk", git = "https://github.com/anoma/namada", rev = "v0.32.1" }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 tokio = { version = "1.26.0", features = ["rt-multi-thread"] }
@@ -74,6 +75,11 @@ criterion = { version = "0.5.1", features = [
 ] }
 httpc-test = "0.1.4"
 
+[patch.crates-io]
+tendermint        = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "romac/allow-misformed-block" }
+tendermint-rpc    = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "romac/allow-misformed-block" }
+tendermint-proto  = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "romac/allow-misformed-block" }
+tendermint-config = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "romac/allow-misformed-block" }
 
 [features]
 default = []


### PR DESCRIPTION
closes https://github.com/Zondax/namadexer/issues/175

This PR use a patch version of tendermint which allow deserializing block with empty last commit and fix the bug following Namada hardfork.