### PR TITLE
Feat/checksums once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "namada_sdk",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tendermint-rpc = { version = "0.35.0", features = ["http-client"] }
 tendermint-proto = "0.35.0"
 clap = { version = "4.4.2", features = ["derive", "env"] }
 ureq = "2.9.1"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = [

--- a/examples/generate.rs
+++ b/examples/generate.rs
@@ -1,8 +1,8 @@
 // Generate tests vectors blocks
-use namada_sdk::tendermint::block::Height;
-use namada_sdk::tendermint_rpc::{Client, HttpClient};
 use std::fs::File;
 use std::io::Write;
+use tendermint::block::Height;
+use tendermint_rpc::{self, Client, HttpClient};
 
 const URL: &str = "http://194.163.180.253:26657";
 const CURRENT_HEIGHT: u32 = 1;

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,5 +1,4 @@
 use crate::config::IndexerConfig;
-use crate::utils::load_checksums;
 use futures::stream::StreamExt;
 use futures_util::pin_mut;
 use futures_util::Stream;
@@ -196,14 +195,6 @@ pub async fn start_indexing(
 
     /********************
      *
-     *  Load checksums
-     *
-     ********************/
-
-    let checksums_map = load_checksums()?;
-
-    /********************
-     *
      *  Init RPC
      *
      ********************/
@@ -232,7 +223,7 @@ pub async fn start_indexing(
     // Block consumer that stores block into the database
     while let Some(block) = rx.recv().await {
         // block is now the block info and the block results
-        if let Err(e) = db.save_block(&block.0, &block.1, &checksums_map).await {
+        if let Err(e) = db.save_block(&block.0, &block.1).await {
             // shutdown producer task
             shutdown.store(true, Ordering::Relaxed);
             tracing::error!("Closing block producer task due to an error saving last block: {e}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@ pub use indexer::start_indexing;
 pub use server::{create_server, start_server, BlockInfo};
 pub use telemetry::{get_subscriber, init_subscriber, setup_logging};
 
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+
 pub const INDEXER_GET_BLOCK_DURATION: &str = "indexer_get_block_duration";
 const DB_SAVE_BLOCK_COUNTER: &str = "db_save_block_count";
 const DB_SAVE_BLOCK_DURATION: &str = "db_save_block_duration";
@@ -28,3 +32,11 @@ const INDEXER_LAST_SAVE_BLOCK_HEIGHT: &str = "indexer_last_save_block_height";
 const INDEXER_LAST_GET_BLOCK_HEIGHT: &str = "indexer_last_get_block_height";
 
 pub const MASP_ADDR: &str = "tnam1pcqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzmefah";
+
+// Checksums for the different transaction types,
+// stored as a global for easy access from anywhere.
+pub(crate) static CHECKSUMS: Lazy<HashMap<String, String>> =
+    // Lazylly load the checksums from the env/file
+    // this helps reducing the overhead of passing checksums to database
+    // functions for data that is initialized once and never changes.
+    Lazy::new(|| utils::load_checksums().expect("Failed to load checksums"));

--- a/tests/save_block.rs
+++ b/tests/save_block.rs
@@ -2,7 +2,6 @@ mod utils;
 
 #[cfg(test)]
 mod save_block {
-    use namadexer::utils::load_checksums;
     use std::fs;
     use tendermint::block::Block;
     use tendermint_rpc::endpoint::block_results;
@@ -18,8 +17,6 @@ mod save_block {
         // now create a fresh database for tests
         let db = create_test_db(helper_db.pool(), TESTING_DB_NAME).await;
 
-        let checksums_map = load_checksums().unwrap();
-
         let data = fs::read_to_string("./tests/blocks_vector.json").unwrap();
         let blocks: Vec<Block> = serde_json::from_str(&data).unwrap();
         let data = fs::read_to_string("./tests/block_results_vector.json").unwrap();
@@ -28,9 +25,7 @@ mod save_block {
         db.create_tables().await.unwrap();
 
         for i in 0..blocks.len() {
-            db.save_block(&blocks[i], &block_results[i], &checksums_map)
-                .await
-                .unwrap();
+            db.save_block(&blocks[i], &block_results[i]).await.unwrap();
         }
 
         db.create_indexes()


### PR DESCRIPTION
This moves the checksums to a global, The reason is that it is not going to change during program execution and is loaded during program start, this condition makes it a good fit for wrapping into a Once Cell that gets lazily initialized.