### PR TITLE
feat: add code_type value and memo data for transactions

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -148,7 +148,6 @@ impl Database {
             .execute(&*self.pool)
             .await?;
 
-
         // Drop any existing views
 
         query(views::get_drop_tx_become_validator_view_query(&self.network).as_str())

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -40,6 +40,8 @@ pub fn get_create_transactions_table_query(network: &str) -> String {
         fee_token TEXT,
         gas_limit_multiplier BIGINT,
         code BYTEA,
+        code_type TEXT,
+        memo BYTEA,
         data JSON,
         return_code INTEGER
     );",


### PR DESCRIPTION
This PR add 2 new columns to the transactions table : `code_type` that translate the code in a human readable string and `memo` which contains the memo data associated with the transaction.

To avoid issue when deploying this new feature the table is altered if needed. Only new indexed block data will have those new values saved. To have previous data a fully resync is needed.