### PR TITLE
metrics: unify the histograms for all batch sizes; record batch size as a separate histogram

### DIFF
--- a/src/bin/indexer.rs
+++ b/src/bin/indexer.rs
@@ -16,10 +16,37 @@ use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 // Block/Evidences/Transactions insterts duration buckets to
 // "scale" metrics in prometheus.
 // we could tweek this
-pub const DB_SAVE_DATA_DURATION_MS_BUCKETS: &[f64; 23] = &[
-    0.005, 1.0, 1.5, 2.0, 2.5, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 10.0, 15.0, 20.0, 22.5,
-    25.0, 30.0, 40.0, 50.0, 60.0,
+pub const DB_SAVE_DATA_DURATION_MS_BUCKETS: &[f64; 26] = &[
+    0.005 * 1000.0,
+    0.01 * 1000.0,
+    0.25 * 1000.0,
+    0.5 * 1000.0,
+    1.0 * 1000.0,
+    1.5 * 1000.0,
+    2.0 * 1000.0,
+    2.5 * 1000.0,
+    3.5 * 1000.0,
+    4.0 * 1000.0,
+    4.5 * 1000.0,
+    5.0 * 1000.0,
+    5.5 * 1000.0,
+    6.0 * 1000.0,
+    6.5 * 1000.0,
+    7.0 * 1000.0,
+    8.0 * 1000.0,
+    10.0 * 1000.0,
+    15.0 * 1000.0,
+    20.0 * 1000.0,
+    22.5 * 1000.0,
+    25.0 * 1000.0,
+    30.0 * 1000.0,
+    40.0 * 1000.0,
+    50.0 * 1000.0,
+    60.0 * 1000.0,
 ];
+
+pub const DB_SAVE_DATA_BATCH_SIZE_BUCKETS: &[f64; 10] =
+    &[1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0, 300.0, 400.0];
 
 pub const GET_BLOCK_DURATION_SECONDS_BUCKETS: &[f64; 11] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
@@ -32,8 +59,12 @@ async fn start_metrics_server(cfg: &PrometheusConfig) -> Result<(), Error> {
     PrometheusBuilder::new()
         .with_http_listener(address)
         .set_buckets_for_metric(
-            Matcher::Prefix("db_save_".to_string()),
+            Matcher::Prefix("db_save_duration_".to_string()),
             DB_SAVE_DATA_DURATION_MS_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Prefix("db_save_batch_size_".to_string()),
+            DB_SAVE_DATA_BATCH_SIZE_BUCKETS,
         )?
         .set_buckets_for_metric(
             Matcher::Prefix(namadexer::INDEXER_GET_BLOCK_DURATION.to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,14 @@ use std::collections::HashMap;
 use once_cell::sync::Lazy;
 
 pub const INDEXER_GET_BLOCK_DURATION: &str = "indexer_get_block_duration";
-const DB_SAVE_BLOCK_COUNTER: &str = "db_save_block_count";
-const DB_SAVE_BLOCK_DURATION: &str = "db_save_block_duration";
-const DB_SAVE_TXS_DURATION: &str = "db_save_transactions_duration";
-const DB_SAVE_EVDS_DURATION: &str = "db_save_evidences_duration";
-const DB_SAVE_COMMIT_SIG_DURATION: &str = "db_save_commit_sig_duration";
+const DB_SAVE_BLOCK_COUNTER: &str = "db_save_count_block";
+const DB_SAVE_BLOCK_DURATION: &str = "db_save_duration_block";
+const DB_SAVE_TXS_DURATION: &str = "db_save_duration_transactions";
+const DB_SAVE_TXS_BATCH_SIZE: &str = "db_save_batch_size_transactions";
+const DB_SAVE_EVDS_DURATION: &str = "db_save_duration_evidences";
+const DB_SAVE_EVDS_BATCH_SIZE: &str = "db_save_batch_size_evidences";
+const DB_SAVE_COMMIT_SIG_DURATION: &str = "db_save_duration_commit_sig";
+const DB_SAVE_COMMIT_SIG_BATCH_SIZE: &str = "db_save_batch_size_commit_sig";
 const INDEXER_LAST_SAVE_BLOCK_HEIGHT: &str = "indexer_last_save_block_height";
 const INDEXER_LAST_GET_BLOCK_HEIGHT: &str = "indexer_last_get_block_height";
 


### PR DESCRIPTION
This helps reduce some more of the redundant metrics as described in https://github.com/Zondax/namadexer/issues/195 and https://github.com/Zondax/namadexer/issues/198.

COMPATIBILITY NOTE: this also renames the `db_save_` metrics to use common prefixes `db_save_duration_`, `db_save_batch_size_`, etc. instead of putting the metric type at the end of the name.